### PR TITLE
Porting Presto UDFs for Presto 0.193

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The details about how to plug in presto UDFs can be found [here](https://www.qub
 
 | Presto Version| Last Compatible Release|
 | ------------- |:-------------:|
-| _ver 0.180_      | current    |
+| _ver 0.193_      | current    |
+| _ver 0.180_      | udfs-2.0.2 |
 | _ver 0.157_      | udfs-2.0.1 |
 | _ver 0.142_      | udfs-1.0.0 |
 | _ver 0.119_      | udfs-0.1.3 |

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.qubole.presto</groupId>
   <artifactId>udfs</artifactId>
   <name>PrestoUDFs</name>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.3-SNAPSHOT</version>
   <description>Common Functions for the Facebook Presto SQL Engine</description>
   <url>https://github.com/qubole/presto-udfs</url>
   <developers>
@@ -151,13 +151,13 @@
     <dependency>
       <groupId>com.facebook.presto</groupId>
       <artifactId>presto-spi</artifactId>
-      <version>0.180</version>
+      <version>0.193</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.facebook.presto</groupId>
       <artifactId>presto-main</artifactId>
-      <version>0.180</version>
+      <version>0.193</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -189,7 +189,7 @@
     <javax.inject.version>1</javax.inject.version>
     <guava.version>18.0</guava.version>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <presto.version>0.180</presto.version>
+    <presto.version>0.193</presto.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <io.airlift.log.version>0.125</io.airlift.log.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <!--
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     -->
-        <presto.version>0.180</presto.version>
+        <presto.version>0.193</presto.version>
         <slice.version>0.15</slice.version>
         <guava.version>18.0</guava.version>
         <javax.inject.version>1</javax.inject.version>

--- a/src/main/java/com/qubole/presto/udfs/sqlFunction/hiveUdfs/Nvl.java
+++ b/src/main/java/com/qubole/presto/udfs/sqlFunction/hiveUdfs/Nvl.java
@@ -16,14 +16,6 @@
 package com.qubole.presto.udfs.sqlFunction.hiveUdfs;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
-import com.facebook.presto.bytecode.BytecodeBlock;
-import com.facebook.presto.bytecode.ClassDefinition;
-import com.facebook.presto.bytecode.CompilerUtils;
-import com.facebook.presto.bytecode.DynamicClassLoader;
-import com.facebook.presto.bytecode.MethodDefinition;
-import com.facebook.presto.bytecode.Parameter;
-import com.facebook.presto.bytecode.Scope;
-import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
@@ -34,22 +26,32 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.gen.CallSiteBinder;
+import com.facebook.presto.util.CompilerUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.BytecodeBlock;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.DynamicClassLoader;
+import io.airlift.bytecode.MethodDefinition;
+import io.airlift.bytecode.Parameter;
+import io.airlift.bytecode.Scope;
+import io.airlift.bytecode.control.IfStatement;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.bytecode.Access.FINAL;
-import static com.facebook.presto.bytecode.Access.PRIVATE;
-import static com.facebook.presto.bytecode.Access.PUBLIC;
-import static com.facebook.presto.bytecode.Access.STATIC;
-import static com.facebook.presto.bytecode.Access.a;
-import static com.facebook.presto.bytecode.CompilerUtils.defineClass;
-import static com.facebook.presto.bytecode.Parameter.arg;
-import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
+import static com.facebook.presto.util.CompilerUtils.defineClass;
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PRIVATE;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.STATIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -130,7 +132,7 @@ public final class Nvl
         Class<?> clazz = ifNull(stackTypes);
         MethodHandle nvlMethodHandle = methodHandle(clazz, "nvl", stackTypes.toArray(new Class<?>[stackTypes.size()]));
 
-        return new ScalarFunctionImplementation(true, ImmutableList.of(true, true), nvlMethodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(true, ImmutableList.of(valueTypeArgumentProperty(USE_BOXED_TYPE), valueTypeArgumentProperty(USE_BOXED_TYPE)), nvlMethodHandle, isDeterministic());
     }
 
     private Class<?> ifNull(List<Class<?>> nativeContainerTypes)


### PR DESCRIPTION
PR is for porting udfs to QDS Presto 0.193.

@stagraqubole we would also need to release a jar before merging this PR I guess. If you can do it then its fine, otherwise i can release it to sonatype using qubole account.